### PR TITLE
"WIFI_P2P" reported as Cellular network type on Samsung devices

### DIFF
--- a/src/Connectivity.Plugin.Android/ConnectivityImplementation.cs
+++ b/src/Connectivity.Plugin.Android/ConnectivityImplementation.cs
@@ -242,7 +242,6 @@ namespace Plugin.Connectivity
 
         public static ConnectionType GetConnectionType(ConnectivityType connectivityType)
         {
-
             switch (connectivityType)
             {
                 case ConnectivityType.Ethernet:
@@ -253,8 +252,14 @@ namespace Plugin.Connectivity
                     return ConnectionType.WiFi;
                 case ConnectivityType.Bluetooth:
                     return ConnectionType.Bluetooth;
-                default:
+                case ConnectivityType.Mobile:
+                case ConnectivityType.MobileDun:
+                case ConnectivityType.MobileHipri:
                     return ConnectionType.Cellular;
+                case ConnectivityType.Dummy:
+                    return ConnectionType.Other;
+                default:
+                    return ConnectionType.Other;
             }
         }
 

--- a/tests/app/ConnectivityTest/ConnectivityTestPage.xaml.cs
+++ b/tests/app/ConnectivityTest/ConnectivityTestPage.xaml.cs
@@ -54,7 +54,7 @@ namespace ConnectivityTest
 			{
 				var stuff = string.Empty;
 				foreach (var i in e.ConnectionTypes)
-					stuff += "/n" + i.ToString();
+					stuff += "\n" + i.ToString();
 				
 				await DisplayAlert("Is Connected", (e.IsConnected ? "YES" : "NO") + stuff, "OK");
 
@@ -67,7 +67,7 @@ namespace ConnectivityTest
             {
                 var stuff = string.Empty;
                 foreach (var i in CrossConnectivity.Current.ConnectionTypes)
-                    stuff += "/n" + i.ToString();
+                    stuff += "\n" + i.ToString();
 
                 await DisplayAlert("Is Connected", (CrossConnectivity.Current.IsConnected ? "YES" : "NO") + stuff, "OK");
 


### PR DESCRIPTION
On Samsung branded Android, there's usually a special network adapter for WiFi Direct which is used to connect to Printers and other devices. This connection is getting incorrectly reported as Cellular network type by ConnectivityPlugin, even when there's no active Cellular connection on the device. This is because the network info of Android looks like this:

TypeName: "WIFI_P2P"
Type: Dummy | MobileDun | Wifi

GetConnectionType() then falls back to ConnectionType.Cellular. This PR should fix this
