### PR TITLE
Set target framework of core-packages to .NetStandard 1.0

### DIFF
--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -25,12 +25,12 @@
      <file src="nuget\readme.txt" target="readme.txt" />
      
       <!--Core-->
-     <file src="src\Connectivity.Plugin\bin\Release\Plugin.Connectivity.dll" target="lib\portable-net45+wp80+win8+wpa81\Plugin.Connectivity.dll" />
-     <file src="src\Connectivity.Plugin\bin\Release\Plugin.Connectivity.xml" target="lib\portable-net45+wp80+win8+wpa81\Plugin.Connectivity.xml" />
-     <file src="src\Connectivity.Plugin\bin\Release\Plugin.Connectivity.pdb" target="lib\portable-net45+wp80+win8+wpa81\Plugin.Connectivity.pdb" />
-     <file src="src\Connectivity.Plugin.Abstractions\bin\Release\Plugin.Connectivity.Abstractions.dll" target="lib\portable-net45+wp80+win8+wpa81\Plugin.Connectivity.Abstractions.dll" />
-     <file src="src\Connectivity.Plugin.Abstractions\bin\Release\Plugin.Connectivity.Abstractions.xml" target="lib\portable-net45+wp80+win8+wpa81\Plugin.Connectivity.Abstractions.xml" />
-     <file src="src\Connectivity.Plugin.Abstractions\bin\Release\Plugin.Connectivity.Abstractions.pdb" target="lib\portable-net45+wp80+win8+wpa81\Plugin.Connectivity.Abstractions.pdb" />
+     <file src="src\Connectivity.Plugin\bin\Release\Plugin.Connectivity.dll" target="lib\netstandard1.0\Plugin.Connectivity.dll" />
+     <file src="src\Connectivity.Plugin\bin\Release\Plugin.Connectivity.xml" target="lib\netstandard1.0\Plugin.Connectivity.xml" />
+     <file src="src\Connectivity.Plugin\bin\Release\Plugin.Connectivity.pdb" target="lib\netstandard1.0\Plugin.Connectivity.pdb" />
+     <file src="src\Connectivity.Plugin.Abstractions\bin\Release\Plugin.Connectivity.Abstractions.dll" target="lib\netstandard1.0\Plugin.Connectivity.Abstractions.dll" />
+     <file src="src\Connectivity.Plugin.Abstractions\bin\Release\Plugin.Connectivity.Abstractions.xml" target="lib\netstandard1.0\Plugin.Connectivity.Abstractions.xml" />
+     <file src="src\Connectivity.Plugin.Abstractions\bin\Release\Plugin.Connectivity.Abstractions.pdb" target="lib\netstandard1.0\Plugin.Connectivity.Abstractions.pdb" />
      
      <!--Win Phone Silverlight-->
      <file src="src\Connectivity.Plugin.WindowsPhone8\bin\Release\Plugin.Connectivity.dll" target="lib\wp80\Plugin.Connectivity.dll" />

--- a/src/Connectivity.Plugin.Abstractions/Connectivity.Plugin.Abstractions.csproj
+++ b/src/Connectivity.Plugin.Abstractions/Connectivity.Plugin.Abstractions.csproj
@@ -13,8 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,6 +41,9 @@
     <Compile Include="ConnectionType.cs" />
     <Compile Include="IConnectivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Connectivity.Plugin.Abstractions/project.json
+++ b/src/Connectivity.Plugin.Abstractions/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+  },
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}

--- a/src/Connectivity.Plugin.Abstractions/project.json
+++ b/src/Connectivity.Plugin.Abstractions/project.json
@@ -1,7 +1,7 @@
-{
+﻿{
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.1"
   },
   "frameworks": {
     "netstandard1.0": {}

--- a/src/Connectivity.Plugin/Connectivity.Plugin.csproj
+++ b/src/Connectivity.Plugin/Connectivity.Plugin.csproj
@@ -13,8 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +43,9 @@
   <ItemGroup>
     <Compile Include="CrossConnectivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Connectivity.Plugin/project.json
+++ b/src/Connectivity.Plugin/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+  },
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}

--- a/src/Connectivity.Plugin/project.json
+++ b/src/Connectivity.Plugin/project.json
@@ -1,7 +1,7 @@
-{
+﻿{
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1"
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.1"
   },
   "frameworks": {
     "netstandard1.0": {}


### PR DESCRIPTION
I've changed the target framework of the two core-projects `Connectivity.Plugin` and `Connectivity.Plugin.Abstractions` to .NetStandard 1.0.

If I read the table on https://docs.microsoft.com/en-us/dotnet/articles/standard/library correctly, this should not change anything to people who are using this package as of today, but it will open up to those who want to target the .NetStandard in any version in their core-project.

This should fix #29