### PR TITLE
Fix UWP IsConnected

### DIFF
--- a/src/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
+++ b/src/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
@@ -63,7 +63,10 @@ namespace Plugin.Connectivity
                 if (profile == null)
                     isConnected = false;
                 else
-                    isConnected = profile.GetNetworkConnectivityLevel() != NetworkConnectivityLevel.None;
+                {
+                    NetworkConnectivityLevel level = profile.GetNetworkConnectivityLevel();
+                    isConnected = level != NetworkConnectivityLevel.None && level != NetworkConnectivityLevel.LocalAccess;
+                }
 
                 return isConnected;
             }

--- a/src/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
+++ b/src/Connectivity.Plugin.WindowsPhone81/ConnectivityImplementation.cs
@@ -64,7 +64,7 @@ namespace Plugin.Connectivity
                     isConnected = false;
                 else
                 {
-                    NetworkConnectivityLevel level = profile.GetNetworkConnectivityLevel();
+                    var level = profile.GetNetworkConnectivityLevel();
                     isConnected = level != NetworkConnectivityLevel.None && level != NetworkConnectivityLevel.LocalAccess;
                 }
 


### PR DESCRIPTION
Fixes #62 and #42  .

Changes Proposed in this pull request:
- Instead of checking only NetworkConnectivityLevel.None, NetworkConnectivityLevel.LocalAccess also needs to be checked.

