### PR TITLE
generate full PDBs so UWP projects can consume

### DIFF
--- a/src/Connectivity.Plugin.Abstractions/Connectivity.Plugin.Abstractions.csproj
+++ b/src/Connectivity.Plugin.Abstractions/Connectivity.Plugin.Abstractions.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Plugin.Connectivity.Abstractions</AssemblyName>
     <RootNamespace>Plugin.Connectivity.Abstractions</RootNamespace>
+
+    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Connectivity.Plugin/Connectivity.Plugin.csproj
+++ b/src/Connectivity.Plugin/Connectivity.Plugin.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Plugin.Connectivity</AssemblyName>
     <RootNamespace>Plugin.Connectivity</RootNamespace>
+
+    <!-- This is a temporary workaround for https://github.com/dotnet/sdk/issues/955 -->
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #101 

Changes Proposed in this pull request:
- Generate Full PDB symbols for netstandard projects to work around UWP bug, for more info see #101 