### PR TITLE
Fix ios ConnectivityChangedEvent sometimes doesn't fire

### DIFF
--- a/src/Connectivity.Plugin.Shared.Apple/ConnectivityImplementation.cs
+++ b/src/Connectivity.Plugin.Shared.Apple/ConnectivityImplementation.cs
@@ -26,6 +26,7 @@ namespace Plugin.Connectivity
 			//start an update on the background.
 			initialTask = Task.Run(() => { UpdateConnected(false);});
 			Reachability.ReachabilityChanged += ReachabilityChanged;
+			UpdateConnected();
 		}
 
 		async void ReachabilityChanged(object sender, EventArgs e)
@@ -57,8 +58,8 @@ namespace Plugin.Connectivity
 
 				var connectionTypes = this.ConnectionTypes.ToArray();
 				OnConnectivityTypeChanged(new ConnectivityTypeChangedEventArgs { IsConnected = isConnected, ConnectionTypes = connectionTypes });
+				previousInternetStatus = internetStatus;
 			}
-			previousInternetStatus = internetStatus;
 		}
 
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes issue #
- Fix ios ConnectivityChangedEvent sometimes doesn't fire
Changes Proposed in this pull request:
- Put previousInternetStatus = internetStatus inside of if(triggerChange) clause
- Call UpdateConnected(); inside constructor


### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Consolidate commits as makes sense